### PR TITLE
Fix fuzzy match for namespaces

### DIFF
--- a/rplugin/python3/deoplete/sources/deoplete_padawan.py
+++ b/rplugin/python3/deoplete/sources/deoplete_padawan.py
@@ -46,7 +46,7 @@ class Source(Base):
                                             log_file)
 
     def get_complete_position(self, context):
-        patterns = [r'[\'"][^\)]*', r'\w*$']
+        patterns = [r'[\'"][^\)]*', r'\b[\w\\]*$']
         result = -1
         result_end = -1
         pos = -1

--- a/test/deoplete_padawan_test.py
+++ b/test/deoplete_padawan_test.py
@@ -49,8 +49,44 @@ class SourceTest(unittest.TestCase):
         #             '0....5....0.^ <- 12
         self.assertEqual(position, 12)
 
+    def test_get_complete_position_for_static_method_call_w_namespace(self):
+        position = self.source.get_complete_position(
+            {'input': '     \Some\Class::getInst'})
+        #             '0....5....0....5..^ <- 18
+        self.assertEqual(position, 18)
+
     def test_get_complete_position_for_fluent_method_calls(self):
         position = self.source.get_complete_position(
             {'input': '$db->select("*")->from("table")->whe'})
         #             '0....5....0....5....0....5....0..^ <- 33
         self.assertEqual(position, 33)
+
+    def test_get_complete_position_for_use_statement(self):
+        position = self.source.get_complete_position(
+            {'input': '  use Class\\'})
+        #             '0....5^ <- 6
+        self.assertEqual(position, 6)
+
+    def test_get_complete_position_for_long_use_statement(self):
+        position = self.source.get_complete_position(
+            {'input': '   use Class\With\Lon'})
+        #             '0....5.^ <- 7
+        self.assertEqual(position, 7)
+
+    def test_get_complete_position_for_new_statement(self):
+        position = self.source.get_complete_position(
+            {'input': ' $ala = new Class\\'})
+        #             '0....5....0.^ <- 12
+        self.assertEqual(position, 12)
+
+    def test_get_complete_position_for_long_new_statement(self):
+        position = self.source.get_complete_position(
+            {'input': ' $x = new Class\With\Ver'})
+        #             '0....5....^ <- 10
+        self.assertEqual(position, 10)
+
+    def test_get_complete_position_for_new_with_root_namespace(self):
+        position = self.source.get_complete_position(
+            {'input': '      new \Date'})
+        #             '0....5....0^ <- 11
+        self.assertEqual(position, 11)


### PR DESCRIPTION
Fix proposition for #6 

@mkusher It works now, however, I'm not sure about one thing. When I have class with namespace like this:

``` php
<?php

namespace My\Name\Space;

class MyClass {
  public function testFunction() {
    new DateTi //case 1
    new \DateTi //case 2
  }
}
```

For case one padawan is giving suggestions when pointing on 9th column (D letter), but for the case 2 when pointing at 10th column (D letter as in case 1).
Is that how it should be?
I'm not even sure if the case 1 should be suggested as the code is invalid (it's creating `My\Name\Space\DateTi...`. For the second case, shouldn't completion work when pointing at backslash (as it is part of the class name)?

With this PR it works nicely for both cases but I want to make sure that's correct.
